### PR TITLE
Replace a unicode right quotation with ansi apostrophe

### DIFF
--- a/container/docker.cheat
+++ b/container/docker.cheat
@@ -33,7 +33,7 @@ docker rm -f $(docker ps -aq)
 # Create a new bash process inside the container and connect it to the terminal
 docker exec -it <container_id> bash
 
-# Print the last lines of a container’s logs
+# Print the last lines of a container's logs
 docker logs --tail 100 <container_id> | less
 
 # Print the last lines of a container's logs and following its logs


### PR DESCRIPTION
I was getting errors after installing the cheat sheets and traced it to a line with a RIGHT SINGLE QUOTATION MARK (U+2019). 


```
thread 'main' panicked at 'byte index 37 is not a char boundary; it is inside '’' (bytes 35..38) of `Print the last lines of a container’s logs`', src/libcore/str/mod.rs:2154:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```