### PR TITLE
Add cheats for Android Firebase Crashlytics test

### DIFF
--- a/mobile/android.cheat
+++ b/mobile/android.cheat
@@ -1,5 +1,8 @@
 % android, device
 
+# Logcat
+adb -s <device> logcat -v time
+
 # Get property
 adb -s <device> shell getprop <property>
 
@@ -15,7 +18,7 @@ adb -s <device> shell pm clear <package>
 # Dispatch a deep-link / open URI
 adb -s <device> shell am start <uri>
 
-$ device: adb devices --- --headers 1 --column 1
+$ device: adb devices | grep -v devices | grep device | cut -f 1
 
 
 
@@ -25,3 +28,18 @@ $ device: adb devices --- --headers 1 --column 1
 "$ANDROID_HOME/tools/emulator" -avd <emulator> -netdelay none -netspeed full
 
 $ emulator: "$ANDROID_HOME/tools/emulator" -list-avds
+
+
+
+% android, Firebase Crashlytics Test
+
+# Enable debug logging on your device
+adb -s <device> shell setprop log.tag.CrashlyticsCore DEBUG
+
+# View the logs in the device logs
+adb -s <device> logcat -s Fabric CrashlyticsCore
+
+# Disable debug mode
+adb -s <device> shell setprop log.tag.CrashlyticsCore INFO
+
+$ device: adb devices | grep -v devices | grep device | cut -f 1


### PR DESCRIPTION
Fixed `adb: unknown command device` issue by updating

    $ device: adb devices --- --headers 1 --column 1
    
      emulator-5554    device
    > R58M605LERP      device
      List of devices attached
      3/3
    devices:

to

    $ device: adb devices | grep -v devices | grep device | cut -f 1
    
      emulator-5554
    > R58M605LERP
      2/2
    devices:


Added firebase crashlytics test command lines:
https://firebase.google.com/docs/crashlytics/force-a-crash?platform=android#enable_debug_logging
