### PR TITLE
Add git reset commands

### DIFF
--- a/code/git.cheat
+++ b/code/git.cheat
@@ -122,7 +122,7 @@ git checkout -b <new_branch_name>
 # Remove commits from local repository (destroy changes)
 git reset --hard HEAD~<number_of_commits>
 
-# Remove commits from local repository (keep changes locally)
+# Remove commits from local repository (keep changes)
 git reset --soft HEAD~<number_of_commits>
 
 $ branch: git branch | awk '{print $NF}'

--- a/code/git.cheat
+++ b/code/git.cheat
@@ -119,6 +119,12 @@ git commit --no-verify
 # Create new branch from current HEAD
 git checkout -b <new_branch_name>
 
+# Remove commits from local repository (destroy changes)
+git reset --hard HEAD~<number_of_commits>
+
+# Remove commits from local repository (keep changes locally)
+git reset --soft HEAD~<number_of_commits>
+
 $ branch: git branch | awk '{print $NF}'
 $ toplevel_directory: git rev-parse --show-toplevel
 $ unstaged_files: git status --untracked-files=no -s --porcelain | awk '{print $NF}' --- --multi true


### PR DESCRIPTION
`git reset --soft HEAD~1` is one of the only git commands I look up almost daily.  It allows you to remove commits from the local repository, while keeping the changes.  If you use the `--hard` flag, the changes will be destroyed.  I don't usually use `git reset` with `--hard`, but it seems to make sense to package it up with the `--soft` option.

By the way, I just discovered `navi` tonight and am so extremely excited I found it.  Such an extremely useful tool.  Thanks for your hard work.