### PR TITLE
Fixed 'List all files of type'

### DIFF
--- a/misc/shell.cheat
+++ b/misc/shell.cheat
@@ -65,7 +65,7 @@ ls -alt
 ls *.<txt>
 
 # List all files of type
-find . -name *.<txt> -print
+find . -name '*.<txt>' -print
 
 # Go back to previous directory
 cd -


### PR DESCRIPTION
Was throwing errors due to missing quotes around '*.<txt>'.