### PR TITLE
Fix typos in curl.cheat

### DIFF
--- a/network/curl.cheat
+++ b/network/curl.cheat
@@ -27,10 +27,10 @@ curl <url> -d <bodykey>=<bodyvalue>
 # send a http request and see the request as well as the response
 curl -v <url>
 
-# send a http request wih a body from a file
+# send a http request with a body from a file
 curl -X <method> <url> --data-binary "@<file>"
 
-# send a http request wih a custom header
+# send a http request with a custom header
 curl -X <method> <url> -H "<headername>: <headervalue>"
 
 $ file: ls


### PR DESCRIPTION
Just a few typos I found on the curl cheatsheet. I did not find contribution guidelines on this repo, please let me know if I'm doing something wrong!