### PR TITLE
README: use proper dash instead of two hyphens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@ Cheatsheets for [navi](https://github.com/denisidoro/navi).
 
 When the user runs navi for the first time, navi prompts to download `.cheat`s from this repository.
 
-If you want to add a cheatsheet for a new command, it's worth checking out [navi-tldr-pages](https://github.com/denisidoro/navi-tldr-pages). You can copy a cheatsheet from there, enhance it --with argument suggestions, for example--, then add it to this repo.
+If you want to add a cheatsheet for a new command, it's worth checking out [navi-tldr-pages](https://github.com/denisidoro/navi-tldr-pages). You can copy a cheatsheet from there, enhance it —with argument suggestions, for example—, then add it to this repo.
 
 In order to add your own repository as a featured cheatsheet repo, please [edit this file](https://github.com/denisidoro/cheats/edit/master/featured_repos.txt). This list will be displayed when `navi repo browse` is run.


### PR DESCRIPTION
Since this part of the sentence talks about command line arguments,
using double hyphens may be confusing since that's the syntax for long CLI options.