### PR TITLE
Update to Compose V2

### DIFF
--- a/container/docker.cheat
+++ b/container/docker.cheat
@@ -53,25 +53,25 @@ $ container_id: docker ps --- --headers 1 --column 1
 
 
 
-% docker-compose
+% docker compose
 
 # Builds, (re)creates, starts, and attaches to containers for all services
-docker-compose up
+docker compose up
 
 # Builds, (re)creates, starts, and dettaches to containers for all services
-docker-compose up -d
+docker compose up -d
 
 # Builds, (re)creates, starts, and attaches to containers for a service
-docker-compose up -d <service_name>
+docker compose up -d <service_name>
 
 # Builds, (re)creates, starts, and dettaches to containers for a service
-docker-compose up -d <service_name>
+docker compose up -d <service_name>
 
 # Print the last lines of a service’s logs
-docker-compose logs --tail 100 <service_name> | less
+docker compose logs --tail 100 <service_name> | less
 
 # Print the last lines of a service's logs and following its logs
-docker-compose logs -f --tail 100 <service_name>
+docker compose logs -f --tail 100 <service_name>
 
 # Stops containers and removes containers, networks created by up
-docker-compose down
+docker compose down


### PR DESCRIPTION
`docker-compose` actually calls Compose V1 and may not work in more modern systems which don't have the older version installed. It also stopped receiving updates in July.

According to the [Docker documentation](https://docs.docker.com/compose/migrate/#how-do-i-switch-to-compose-v2), switching only involves  going from `docker-compose` to `docker compose`, which is what this PR does.